### PR TITLE
Add trigger for RQCD CI (GitLab)

### DIFF
--- a/.github/workflows/rqcd.yml
+++ b/.github/workflows/rqcd.yml
@@ -1,0 +1,23 @@
+name: Trigger RQCD CI
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        cluster: ['master', 'qp4']
+
+    steps:
+    - name: Trigger CI Job
+      uses: pjgeorg/gitlab-trigger-ci@v2
+      with:
+        host: "rqcd.ur.de"
+        port: 8443
+        ca-bundle: ${{ secrets.RQCD_CA_BUNDLE }}
+        project-id: 888
+        token: ${{ secrets.RQCD_TRIGGER_TOKEN }}
+        ref:  ${{ matrix.cluster }}


### PR DESCRIPTION
Only triggers CI on push to branch master. Maybe change to branch devel later, once master is "stable".
Not triggered for pull request, i.e. more like a regression test for RQCD systems.